### PR TITLE
一个页面同时使用多个transfer组件的问题修复

### DIFF
--- a/src/Transfer.js
+++ b/src/Transfer.js
@@ -172,6 +172,7 @@ class Transfer extends React.Component {
     }
 
     _removeJustMoved(cb) {
+        let me = this;
         let data = deepcopy(this.state);
         data.chosen.forEach((item, index) => {
             item.justMoved = false;

--- a/src/Transfer.js
+++ b/src/Transfer.js
@@ -66,6 +66,7 @@ class Transfer extends React.Component {
     }
 
     locateItem(value, position) {
+        let me = this;
         if (value === "") {
             return; 
         }


### PR DESCRIPTION
1. 当一个页面有两个transfer组件时，点击第一个组件中的item，会导致第二个组件的初始数据渲染成和第一个组件的一模一样。
2. 使用组件的定位搜索时，也会造成数据错乱的问题。
